### PR TITLE
Refactor: Integrate Hilt and Navigation Compose

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -71,7 +71,7 @@ dependencies {
     implementation(libs.coil.network.okhttp)
 
     implementation(libs.androidx.lifecycle.viewmodel.compose)
-    implementation("io.github.ilyapavlovskii:youtubeplayer-compose:2024.02.25")
+    implementation(libs.youtubeplayer.compose)
 
 
     implementation(libs.androidx.material3)
@@ -79,8 +79,10 @@ dependencies {
     implementation(libs.retrofit)
     // Hilt Core
     implementation(libs.hilt.android)
+    implementation(libs.androidx.navigation.compose)
     kapt(libs.hilt.compiler)
     implementation(libs.androidx.hilt.navigation.compose.v120)
+    implementation(libs.kotlinx.serialization.json)
 
 
 // Hilt Navigation Compose

--- a/app/src/main/java/com/sharon/jiken/features/anime_details/presentation/screens/widgets/AnimeDetailsScreen.kt
+++ b/app/src/main/java/com/sharon/jiken/features/anime_details/presentation/screens/widgets/AnimeDetailsScreen.kt
@@ -1,5 +1,6 @@
 package com.sharon.jiken.features.anime_details.presentation.screens.widgets
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -37,6 +38,7 @@ import com.sharon.jiken.features.anime_details.presentation.AnimeDetailsViewMode
 import com.sharon.jiken.features.anime_details.presentation.intents.AnimeDetailsIntent
 import com.sharon.jiken.features.anime_details.presentation.screens.state.AnimeDetailsStatus
 import com.sharon.jiken.features.main.presentation.screens.widgets.RoundedCornerImage
+
 
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/java/com/sharon/jiken/features/main/presentation/screens/MainActivity.kt
+++ b/app/src/main/java/com/sharon/jiken/features/main/presentation/screens/MainActivity.kt
@@ -6,6 +6,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -14,6 +15,7 @@ import androidx.navigation.navArgument
 import com.sharon.jiken.features.anime_details.presentation.screens.widgets.AnimeDetailsScreen
 import com.sharon.jiken.ui.theme.JikenTheme
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.serialization.Serializable
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -27,11 +29,11 @@ class MainActivity : ComponentActivity() {
                 val navController = rememberNavController()
 
                 NavHost(
-                    navController = navController, startDestination = "anime_list"
+                    navController = navController, startDestination = AnimeList
                 ) {
-                    composable("anime_list") {
+                    composable<AnimeList> {
                         AnimeListScreen { animeId ->
-                            navController.navigate("anime_details/$animeId")
+                            navController.navigate(AnimeDetails(animeId))
                         }
                     }
 
@@ -48,6 +50,15 @@ class MainActivity : ComponentActivity() {
         }
     }
 }
+
+
+
+
+@Serializable
+object AnimeList
+
+@Serializable
+class AnimeDetails(val id: Int)
 
 
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,14 +1,15 @@
 [versions]
-agp = "8.11.0-alpha03"
+agp = "8.11.0-alpha06"
 coilNetworkOkhttp = "3.1.0"
 gson = "2.12.1"
 hiltCompiler = "2.56.1"
-hiltNavigationComposeVersion = "1.2.0"
+hiltNavigationComposeVersion = "2.8.9"
 kotlin = "2.0.21"
 coreKtx = "1.10.1"
 junit = "4.13.2"
 junitVersion = "1.1.5"
 espressoCore = "3.5.1"
+kotlinxSerializationJson = "1.8.1"
 lifecycleRuntimeKtx = "2.6.1"
 activityCompose = "1.8.0"
 composeBom = "2024.09.00"
@@ -20,6 +21,8 @@ hiltNavigationCompose="2.56.1"
 hiltAndroidCompiler="2.56.1"
 loggingInterceptor="5.0.0-alpha.14"
 runtimeLivedata = "1.7.8"
+navigationCompose = "2.8.9"
+youtubeplayerCompose = "2024.02.25"
 
 [libraries]
 androidx-hilt-navigation-compose-v120 = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hiltNavigationComposeVersion" }
@@ -29,6 +32,7 @@ coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coilNe
 coil-network-okhttp = { module = "io.coil-kt.coil3:coil-network-okhttp", version.ref = "coilNetworkOkhttp" }
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hiltAndroidCompiler" }
 hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hiltCompiler" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "loggingInterceptor" }
 converter-gson = { module = "com.squareup.retrofit2:converter-gson", version.ref = "retrofitVersion" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -49,6 +53,8 @@ androidx-material3 = { group = "androidx.compose.material3", name = "material3" 
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofitVersion" }
 hilt = { module = "androidx.hilt:hilt-compiler", version.ref = "hilt-version" }
 hilt-android-compiler-v248 = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hiltAndroidCompiler" }
+androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
+youtubeplayer-compose = { module = "io.github.ilyapavlovskii:youtubeplayer-compose", version.ref = "youtubeplayerCompose" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
This commit integrates Hilt with Navigation Compose to improve dependency injection and navigation within the app.

-   **build.gradle.kts:**
    -   Added `androidx.navigation:navigation-compose` dependency for Compose navigation.
    -   Added `org.jetbrains.kotlinx:kotlinx-serialization-json` dependency to manage serialization and navigation.
    -   Updated `hiltNavigationComposeVersion` to version `2.8.9`.
-   **libs.versions.toml:**
    - Added `navigationCompose` variable for `androidx.navigation:navigation-compose`.
    - Added `kotlinxSerializationJson` variable for `org.jetbrains.kotlinx:kotlinx-serialization-json`.
-   **MainActivity.kt:**
    - Used `NavHost` with `composable` to define navigation routes for anime list and details screens.
    - Replaced hardcoded route names with serializable classes `AnimeList` and `AnimeDetails`.
    - Passed parameters via navigation arguments.
- **AnimeDetailsScreen.kt:**
    - Added Image compose to the screen.
- **.idea/misc.xml**
   - Remove unnecessary xml tag.
/gemini review this please